### PR TITLE
Added option that prevents token from being generated on model creation

### DIFF
--- a/lib/has_secure_token.rb
+++ b/lib/has_secure_token.rb
@@ -24,11 +24,11 @@ module ActiveRecord
       # Note that it's still possible to generate a race condition in the database in the same way that
       # <tt>validates_uniqueness_of</tt> can. You're encouraged to add a unique index in the database to deal
       # with this even more unlikely scenario.
-      def has_secure_token(attribute = :token)
+      def has_secure_token(attribute = :token, generate_on_create = true)
         # Load securerandom only when has_secure_token is used.
         require 'active_support/core_ext/securerandom'
         define_method("regenerate_#{attribute}") { update_attributes attribute => self.class.generate_unique_secure_token }
-        before_create { self.send("#{attribute}=", self.class.generate_unique_secure_token) unless self.send("#{attribute}?")}
+        before_create { self.send("#{attribute}=", self.class.generate_unique_secure_token) if generate_on_create && !self.send("#{attribute}?")}
       end
 
       def generate_unique_secure_token

--- a/test/has_secure_token_test.rb
+++ b/test/has_secure_token_test.rb
@@ -9,23 +9,29 @@ class SecureTokenTest < MiniTest::Unit::TestCase
     @user.save
     refute_nil @user.token
     refute_nil @user.auth_token
+    assert_nil @user.not_generated_on_create_token
   end
 
   def test_regenerating_the_secure_token
     @user.save
     old_token = @user.token
     old_auth_token = @user.auth_token
+    old_not_generated_on_create_token = @user.not_generated_on_create_token
     @user.regenerate_token
     @user.regenerate_auth_token
+    @user.regenerate_not_generated_on_create_token
 
     refute_equal @user.token, old_token
     refute_equal @user.auth_token, old_auth_token
+    refute_equal @user.not_generated_on_create_token, old_not_generated_on_create_token
   end
 
   def test_token_value_not_overwritten_when_present
     @user.token = "custom-secure-token"
+    @user.not_generated_on_create_token = "custom-secure-token"
     @user.save
 
     assert_equal @user.token, "custom-secure-token"
+    assert_equal @user.not_generated_on_create_token, "custom-secure-token"
   end
 end

--- a/test/models/user.rb
+++ b/test/models/user.rb
@@ -1,4 +1,5 @@
 class User < ActiveRecord::Base
   has_secure_token
   has_secure_token :auth_token
+  has_secure_token :not_generated_on_create_token, false
 end

--- a/test/schema.rb
+++ b/test/schema.rb
@@ -2,5 +2,6 @@ ActiveRecord::Schema.define(:version => 1) do
   create_table :users do |t|
     t.string :token
     t.string :auth_token
+    t.string :not_generated_on_create_token
   end
 end


### PR DESCRIPTION
When adding has_secure_token to a model, it might be useful in some cases to prevent the token from being generated when the model is created. I've added a `generate_on_create' option to has_secure_token, which is defaulted to true. When the option is set to false, the token will not be generated on the creation of the model.
