### PR TITLE
User should be able to provide token size

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,13 @@ gemfile:
   - gemfiles/rails4_0.gemfile
   - gemfiles/rails4_1.gemfile
   - gemfiles/rails4_2.gemfile
+before_install:
+- gem update --system
+- gem install bundler
+install: bundle install
+script: bundle exec rake build
+env:
+  global:
+    secure: 0dc92adb26454f7a8fcf0639f9f85150fd82b08cabfe8a66e0c5dc85a9cdddbc83b38468f863048af3e7dec3dd3e354e0a50c1b327a1a9f556357897e13e8bc6
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -62,6 +62,22 @@ user.auth_token # => "pX27zsMN2ViQKta1bGfLmVJE"
 user.regenerate_auth_token # => true
 ```
 
+To generate `tokens` as per desired length:
+
+```ruby
+#schema: User(token:string, auth_secret:string)
+class User < ActiveRecord::Base
+  has_secure_token   # default token size 24
+  has_secure_token :auth_secret, token_size: 80
+end
+
+user = User.new
+user.save
+user.token # => "6UFUgE2vXsXcQT64K9yQE59M"
+user.secret_token # => "6JTE6tZkBgbA6H426WkZteHZtzq1viVapD8QJ5B8v6G9zaxmSQHxUULNSM5moZ4wesNb2LHQSSQHm4vU"
+user.regenerate_secret_token # => true
+```
+
 ## Running tests
 
 Running

--- a/lib/has_secure_token.rb
+++ b/lib/has_secure_token.rb
@@ -10,29 +10,35 @@ module ActiveRecord
       #   class User < ActiveRecord::Base
       #     has_secure_token
       #     has_secure_token :auth_token
+      #
+      #     # will generate token 80 character long, Default is 24 character long
+      #     has_secure_token :auth_secret, token_size: 80
       #   end
       #
       #   user = User.new
       #   user.save
       #   user.token # => "pX27zsMN2ViQKta1bGfLmVJE"
       #   user.auth_token # => "77TMHrHJFvFDwodq8w7Ev2m7"
+      #   user.auth_secret # => "7vUrfsD6K9GazaY8J7Acxsw3E6wU93TMe9DHWuNe5yj9yfwneBRuH1pdFmNCCo4k3XxMiw8H9i1ectQd"
       #   user.regenerate_token # => true
       #   user.regenerate_auth_token # => true
+      #   user.regenerate_auth_secret # => true
       #
       # SecureRandom::base58 is used to generate the 24-character unique token, so collisions are highly unlikely.
       #
       # Note that it's still possible to generate a race condition in the database in the same way that
       # <tt>validates_uniqueness_of</tt> can. You're encouraged to add a unique index in the database to deal
       # with this even more unlikely scenario.
-      def has_secure_token(attribute = :token)
+      def has_secure_token(attribute = :token, opts = {})
         # Load securerandom only when has_secure_token is used.
+        size = opts[:token_size] || 24
         require 'active_support/core_ext/securerandom'
-        define_method("regenerate_#{attribute}") { update_attributes attribute => self.class.generate_unique_secure_token }
-        before_create { self.send("#{attribute}=", self.class.generate_unique_secure_token) unless self.send("#{attribute}?")}
+        define_method("regenerate_#{attribute}") { update_attributes attribute => self.class.generate_unique_secure_token(size) }
+        before_create { self.send("#{attribute}=", self.class.generate_unique_secure_token(size)) unless self.send("#{attribute}?")}
       end
 
-      def generate_unique_secure_token
-        SecureRandom.base58(24)
+      def generate_unique_secure_token(size)
+        SecureRandom.base58(size)
       end
     end
   end

--- a/test/has_secure_token_test.rb
+++ b/test/has_secure_token_test.rb
@@ -15,11 +15,14 @@ class SecureTokenTest < MiniTest::Unit::TestCase
     @user.save
     old_token = @user.token
     old_auth_token = @user.auth_token
+    old_auth_secret = @user.auth_secret
     @user.regenerate_token
     @user.regenerate_auth_token
+    @user.regenerate_auth_secret
 
     refute_equal @user.token, old_token
     refute_equal @user.auth_token, old_auth_token
+    refute_equal @user.auth_secret, old_auth_secret
   end
 
   def test_token_value_not_overwritten_when_present
@@ -27,5 +30,18 @@ class SecureTokenTest < MiniTest::Unit::TestCase
     @user.save
 
     assert_equal @user.token, "custom-secure-token"
+  end
+
+  def test_default_token_size
+    @user.save
+
+    assert_equal @user.token.length, 24
+    assert_equal @user.auth_token.length, 24
+  end
+
+  def test_user_can_update_token_size
+    @user.save
+
+    assert_equal @user.auth_secret.length, 80
   end
 end

--- a/test/models/user.rb
+++ b/test/models/user.rb
@@ -1,4 +1,5 @@
 class User < ActiveRecord::Base
   has_secure_token
   has_secure_token :auth_token
+  has_secure_token :auth_secret, token_size: 80
 end

--- a/test/schema.rb
+++ b/test/schema.rb
@@ -2,5 +2,6 @@ ActiveRecord::Schema.define(:version => 1) do
   create_table :users do |t|
     t.string :token
     t.string :auth_token
+    t.string :auth_secret
   end
 end


### PR DESCRIPTION
### UPDATE
1. User should be able to provide required token size
2. Default size will be 24 char long
### Usecase:

``` ruby
class User < ActiveRecord::Base
  has_secure_token   # default token size is 24
  has_secure_token :auth_secret, token_size: 50 # auth_secret token size is 50
end
```

``` ruby
user = User.new
user.save
user.token # => 'pX27zsMN2ViQKta1bGfLmVJE'
user.auth_secret # => '7vUrfsD6K9GazaY8J7Acxsw3E6wU93TMe9DHWuNe5yj9yfwneB'
```

> Added test cases and tested on my ongoing project, working as expected. 

Also check: [issue-10](https://github.com/robertomiranda/has_secure_token/issues/10)

**Updated README**

**Use latest bundler version in CI**
